### PR TITLE
Enable live resizing for aui panels

### DIFF
--- a/src/mainwindow.py
+++ b/src/mainwindow.py
@@ -50,7 +50,8 @@ class MainWindow(wx.Frame):
         self.old_versions = []
         self.printing = html2.PrintingSystem(self)
 
-        self.aui = aui.AuiManager(self)
+        extra_flags = aui.AUI_MGR_LIVE_RESIZE
+        self.aui = aui.AuiManager(self, flags=extra_flags)
         self.menubar = menu.MenuBar(self)
         self.SetMenuBar(self.menubar)
         self.toolbar = toolbar.ToolBar(self)

--- a/src/mainwindow.py
+++ b/src/mainwindow.py
@@ -50,7 +50,7 @@ class MainWindow(wx.Frame):
         self.old_versions = []
         self.printing = html2.PrintingSystem(self)
 
-        extra_flags = aui.AUI_MGR_LIVE_RESIZE
+        extra_flags = aui.AUI_MGR_DEFAULT | aui.AUI_MGR_LIVE_RESIZE
         self.aui = aui.AuiManager(self, flags=extra_flags)
         self.menubar = menu.MenuBar(self)
         self.SetMenuBar(self.menubar)


### PR DESCRIPTION
Enables live resize for panels.

Unfortunately doing what I had originally planned with customizing the panels proved to be very difficult (requiring a ton of code to be changed and some things to be broken). This is mainly due to the fact that Berean uses AUI from wxwidgets rather than the pure-python version as I had hoped. Thus, there isn't the kind of customization ability I need with the current setup. (so I left off doing that).

Therefore this PR is the only (worthwhile) change I've made. I hope it helps. 🙂  

Blessings,
Noah